### PR TITLE
refactor: improve js_os_exec performances by computing fd_max using /…

### DIFF
--- a/builder/custom/qjs/patches/2024-01-13/quickjs-libc.patch
+++ b/builder/custom/qjs/patches/2024-01-13/quickjs-libc.patch
@@ -87,7 +87,7 @@ index d4f4d67..26d7f7f 100644
 +                            max_fd = fd;
 +                        }
 +                    }
-+                    if (max_fd  > 0) {
++                    if (max_fd > 0) {
 +                        fd_max = max_fd;
 +                    }
 +                    closedir(dir);

--- a/builder/custom/qjs/patches/2024-01-13/quickjs-libc.patch
+++ b/builder/custom/qjs/patches/2024-01-13/quickjs-libc.patch
@@ -1,5 +1,5 @@
 diff --git a/quickjs-libc.c b/quickjs-libc.c
-index d4f4d67..97f1144 100644
+index d4f4d67..26d7f7f 100644
 --- a/quickjs-libc.c
 +++ b/quickjs-libc.c
 @@ -71,6 +71,13 @@ typedef sig_t sighandler_t;
@@ -61,7 +61,44 @@ index d4f4d67..97f1144 100644
  #undef DEF
  };
  
-@@ -3183,6 +3216,73 @@ static JSValue js_os_dup2(JSContext *ctx, JSValueConst this_val,
+@@ -3026,6 +3059,36 @@ static JSValue js_os_exec(JSContext *ctx, JSValueConst this_val,
+             }
+         }
+ 
++#if defined(__linux__)
++        int pid = getpid();
++        int max_fd = 0;
++        char path[32];
++        struct stat statbuf;
++        sprintf(path, "/proc/%d/fd", pid);
++        if (stat(path, &statbuf) == 0) {
++            if (S_ISDIR(statbuf.st_mode)) {
++                DIR *dir = opendir(path);
++                if (dir) {
++                    struct dirent *subdir;
++                    int fd;
++                    for(;;) {
++                        subdir = readdir(dir);
++                        if (!subdir) {
++                            break;
++                        }
++                        fd = atoi(subdir->d_name);
++                        if (fd > max_fd) {
++                            max_fd = fd;
++                        }
++                    }
++                    if (max_fd  > 0) {
++                        fd_max = max_fd;
++                    }
++                    closedir(dir);
++                }
++            }
++        }
++#endif
+         for(i = 3; i < fd_max; i++)
+             close(i);
+         if (cwd) {
+@@ -3183,6 +3246,73 @@ static JSValue js_os_dup2(JSContext *ctx, JSValueConst this_val,
      return JS_NewInt32(ctx, ret);
  }
  
@@ -135,7 +172,7 @@ index d4f4d67..97f1144 100644
  #endif /* !_WIN32 */
  
  #ifdef USE_WORKER
-@@ -3729,6 +3829,16 @@ static const JSCFunctionListEntry js_os_funcs[] = {
+@@ -3729,6 +3859,16 @@ static const JSCFunctionListEntry js_os_funcs[] = {
      JS_CFUNC_DEF("dup", 1, js_os_dup ),
      JS_CFUNC_DEF("dup2", 2, js_os_dup2 ),
  #endif


### PR DESCRIPTION
…proc under linux

This MR  improves the performances of `js_os_exec` (see https://github.com/bellard/quickjs/pull/209#issuecomment-1946404153)